### PR TITLE
Add CLI builds to release workflow and package manager support

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -240,3 +240,55 @@ cd web && bun run dev
 # Website tests (Playwright)
 cd web && bun run test
 ```
+
+## Releasing
+
+### Release Workflow
+
+Releases are automated via `.github/workflows/release.yml`. Pushing a tag triggers the build:
+
+```bash
+# Create and push a release tag
+git tag v0.1.2
+git push origin v0.1.2
+```
+
+The workflow builds:
+- **CLI**: `shard-cli-{platform}.{tar.gz,zip}` for macOS (arm64/x64), Windows, Linux
+- **Desktop**: `shard-launcher-{platform}.{dmg,msi,exe,AppImage,deb}`
+- **Checksums**: `SHA256SUMS.txt`
+
+### Release Artifacts
+
+| Component | Platforms | Formats |
+|-----------|-----------|---------|
+| CLI | macOS ARM/Intel, Windows, Linux | `.tar.gz` (Unix), `.zip` (Windows) |
+| Desktop | macOS ARM/Intel | `.dmg` |
+| Desktop | Windows | `.msi`, `-setup.exe` |
+| Desktop | Linux | `.AppImage`, `.deb` |
+
+### Package Managers
+
+| Manager | Package | Repository |
+|---------|---------|------------|
+| **Homebrew** | CLI + Desktop | [th0rgal/homebrew-shard](https://github.com/th0rgal/homebrew-shard) |
+| **Winget** | Desktop | Template in `packaging/winget/` |
+| **Scoop** | CLI | Template in `packaging/scoop/` |
+| **AUR** | CLI + Desktop | Templates in `packaging/aur/` |
+| **Flathub** | Desktop | Template in `packaging/flathub/` |
+
+### Post-Release Checklist
+
+1. Download `SHA256SUMS.txt` from the release
+2. Update Homebrew tap with new version and hashes
+3. Submit Winget PR to `microsoft/winget-pkgs`
+4. Update Scoop bucket (if created)
+5. Update AUR packages
+6. Update Flathub manifest (if submitted)
+
+### Links
+
+- **Website**: https://shard.thomas.md
+- **Repository**: https://github.com/th0rgal/shard
+- **Releases**: https://github.com/th0rgal/shard/releases
+- **Homebrew Tap**: https://github.com/th0rgal/homebrew-shard

--- a/.codex/CODEX.md
+++ b/.codex/CODEX.md
@@ -127,3 +127,22 @@ Shard is a minimal, clean, CLI-first Minecraft launcher focused on stability, re
 - Glassmorphism with `backdrop-filter: blur()` on elevated surfaces.
 - Accent colors: `--accent-primary` (warm amber #e8a855).
 - Border-radius scale: 4px (tiny), 6px (small), 8px (medium), 10px (standard), 12px (large).
+
+## Releasing
+
+Releases are automated via `.github/workflows/release.yml`. Push a tag to trigger:
+
+```bash
+git tag v0.1.2 && git push origin v0.1.2
+```
+
+Artifacts produced:
+- **CLI**: `shard-cli-{macos-arm64,macos-x64,windows-x64,linux-x64}.{tar.gz,zip}`
+- **Desktop**: `shard-launcher-{platform}.{dmg,msi,exe,AppImage,deb}`
+
+Package manager templates are in `packaging/` (Winget, Scoop, AUR, Flathub).
+Homebrew tap: [th0rgal/homebrew-shard](https://github.com/th0rgal/homebrew-shard)
+
+## Links
+- Website: https://shard.thomas.md
+- Repository: https://github.com/th0rgal/shard

--- a/.cursor/rules/context.mdx
+++ b/.cursor/rules/context.mdx
@@ -110,6 +110,24 @@ The UI uses macOS-inspired glassmorphism:
 - Text colors: `--text-primary`, `--text-secondary`, `--text-muted`
 - Geist Sans/Mono fonts
 
+## Releasing
+
+Releases are automated via `.github/workflows/release.yml`. Push a tag to trigger:
+
+```bash
+git tag v0.1.2 && git push origin v0.1.2
+```
+
+Artifacts:
+- **CLI**: `shard-cli-{platform}.{tar.gz,zip}`
+- **Desktop**: `shard-launcher-{platform}.{dmg,msi,exe,AppImage,deb}`
+
+Package manager templates in `packaging/`. Homebrew tap: `th0rgal/homebrew-shard`.
+
+## Links
+- Website: https://shard.thomas.md
+- Repository: https://github.com/th0rgal/shard
+
 ## Sync Note
 
 Keep aligned with `.claude/CLAUDE.md` and `.codex/CODEX.md`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,27 +14,93 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  # Build CLI binaries for all platforms
+  build-cli:
     strategy:
       fail-fast: false
       matrix:
         include:
-          # macOS ARM (Apple Silicon)
           - platform: macos-latest
             target: aarch64-apple-darwin
-            name: macOS-arm64
-          # macOS Intel (cross-compiled from ARM runner)
+            artifact: shard-cli-macos-arm64
           - platform: macos-latest
             target: x86_64-apple-darwin
-            name: macOS-x64
-          # Windows
+            artifact: shard-cli-macos-x64
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
-            name: Windows-x64
-          # Linux
+            artifact: shard-cli-windows-x64
           - platform: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            name: Linux-x64
+            artifact: shard-cli-linux-x64
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: './launcher -> target'
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev
+
+      - name: Build CLI
+        working-directory: launcher
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Prepare artifact (Unix)
+        if: matrix.platform != 'windows-latest'
+        run: |
+          mkdir -p dist
+          cp launcher/target/${{ matrix.target }}/release/shard dist/
+          cd dist && tar -czvf ../${{ matrix.artifact }}.tar.gz shard
+
+      - name: Prepare artifact (Windows)
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist
+          Copy-Item launcher/target/${{ matrix.target }}/release/shard.exe dist/
+          Compress-Archive -Path dist/shard.exe -DestinationPath ${{ matrix.artifact }}.zip
+
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            ${{ matrix.artifact }}.tar.gz
+            ${{ matrix.artifact }}.zip
+          if-no-files-found: ignore
+
+  # Build desktop app for all platforms
+  build-desktop:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            target: aarch64-apple-darwin
+            name: macos-arm64
+          - platform: macos-latest
+            target: x86_64-apple-darwin
+            name: macos-x64
+          - platform: windows-latest
+            target: x86_64-pc-windows-msvc
+            name: windows-x64
+          - platform: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            name: linux-x64
 
     runs-on: ${{ matrix.platform }}
 
@@ -76,37 +142,111 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # macOS code signing & notarization
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # Windows code signing
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: desktop
-          tagName: ${{ github.ref_name }}
-          releaseName: 'Shard ${{ github.ref_name }}'
-          releaseBody: |
-            ## Downloads
+          args: --target ${{ matrix.target }}
+
+      - name: Rename artifacts for clarity
+        shell: bash
+        run: |
+          mkdir -p renamed-artifacts
+          # Find and rename desktop artifacts with clear names
+          if [ "${{ matrix.platform }}" = "macos-latest" ]; then
+            find desktop/src-tauri/target/${{ matrix.target }}/release/bundle -name "*.dmg" -exec cp {} renamed-artifacts/shard-launcher-${{ matrix.name }}.dmg \; 2>/dev/null || true
+          elif [ "${{ matrix.platform }}" = "windows-latest" ]; then
+            find desktop/src-tauri/target/${{ matrix.target }}/release/bundle -name "*.msi" -exec cp {} renamed-artifacts/shard-launcher-${{ matrix.name }}.msi \; 2>/dev/null || true
+            find desktop/src-tauri/target/${{ matrix.target }}/release/bundle -name "*-setup.exe" -exec cp {} renamed-artifacts/shard-launcher-${{ matrix.name }}-setup.exe \; 2>/dev/null || true
+          elif [ "${{ matrix.platform }}" = "ubuntu-22.04" ]; then
+            find desktop/src-tauri/target/${{ matrix.target }}/release/bundle -name "*.AppImage" -exec cp {} renamed-artifacts/shard-launcher-${{ matrix.name }}.AppImage \; 2>/dev/null || true
+            find desktop/src-tauri/target/${{ matrix.target }}/release/bundle -name "*.deb" -exec cp {} renamed-artifacts/shard-launcher-${{ matrix.name }}.deb \; 2>/dev/null || true
+          fi
+
+      - name: Upload desktop artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-${{ matrix.name }}
+          path: renamed-artifacts/*
+          if-no-files-found: ignore
+
+  # Create the GitHub release with all artifacts
+  release:
+    needs: [build-cli, build-desktop]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Flatten artifacts
+        run: |
+          mkdir -p release-files
+          find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.dmg" -o -name "*.msi" -o -name "*.exe" -o -name "*.AppImage" -o -name "*.deb" \) -exec cp {} release-files/ \;
+          ls -la release-files/
+
+      - name: Generate checksums
+        working-directory: release-files
+        run: |
+          sha256sum * > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          name: Shard ${{ github.ref_name }}
+          body: |
+            ## Desktop App (Shard Launcher)
 
             | Platform | Download |
             |----------|----------|
-            | macOS (Apple Silicon) | `.dmg` (arm64) |
-            | macOS (Intel) | `.dmg` (x64) |
-            | Windows | `.msi` or `.exe` |
-            | Linux | `.AppImage` or `.deb` |
+            | macOS (Apple Silicon) | [`shard-launcher-macos-arm64.dmg`](https://github.com/th0rgal/shard/releases/download/${{ github.ref_name }}/shard-launcher-macos-arm64.dmg) |
+            | macOS (Intel) | [`shard-launcher-macos-x64.dmg`](https://github.com/th0rgal/shard/releases/download/${{ github.ref_name }}/shard-launcher-macos-x64.dmg) |
+            | Windows (installer) | [`shard-launcher-windows-x64.msi`](https://github.com/th0rgal/shard/releases/download/${{ github.ref_name }}/shard-launcher-windows-x64.msi) |
+            | Windows (setup) | [`shard-launcher-windows-x64-setup.exe`](https://github.com/th0rgal/shard/releases/download/${{ github.ref_name }}/shard-launcher-windows-x64-setup.exe) |
+            | Linux (AppImage) | [`shard-launcher-linux-x64.AppImage`](https://github.com/th0rgal/shard/releases/download/${{ github.ref_name }}/shard-launcher-linux-x64.AppImage) |
+            | Linux (Debian) | [`shard-launcher-linux-x64.deb`](https://github.com/th0rgal/shard/releases/download/${{ github.ref_name }}/shard-launcher-linux-x64.deb) |
 
-            ### Installation
+            ## CLI
 
-            **macOS**: Open the `.dmg` and drag Shard to Applications.
+            | Platform | Download |
+            |----------|----------|
+            | macOS (Apple Silicon) | [`shard-cli-macos-arm64.tar.gz`](https://github.com/th0rgal/shard/releases/download/${{ github.ref_name }}/shard-cli-macos-arm64.tar.gz) |
+            | macOS (Intel) | [`shard-cli-macos-x64.tar.gz`](https://github.com/th0rgal/shard/releases/download/${{ github.ref_name }}/shard-cli-macos-x64.tar.gz) |
+            | Windows | [`shard-cli-windows-x64.zip`](https://github.com/th0rgal/shard/releases/download/${{ github.ref_name }}/shard-cli-windows-x64.zip) |
+            | Linux | [`shard-cli-linux-x64.tar.gz`](https://github.com/th0rgal/shard/releases/download/${{ github.ref_name }}/shard-cli-linux-x64.tar.gz) |
 
-            **Windows**: Run the `.msi` installer or portable `.exe`.
+            ## Installation
+
+            ### Desktop App
+
+            **macOS**: Download the `.dmg`, open it, and drag Shard to Applications.
+
+            **Windows**: Run the `.msi` installer or the setup `.exe`.
 
             **Linux**: Make the `.AppImage` executable (`chmod +x`) and run, or install the `.deb` package.
-          releaseDraft: true
-          prerelease: false
-          args: --target ${{ matrix.target }}
+
+            ### CLI
+
+            **macOS/Linux**:
+            ```bash
+            # Extract and move to PATH
+            tar -xzf shard-cli-*.tar.gz
+            sudo mv shard /usr/local/bin/
+            ```
+
+            **Windows**: Extract the `.zip` and add `shard.exe` to your PATH.
+
+            ## Checksums
+
+            See `SHA256SUMS.txt` for file integrity verification.
+          files: release-files/*

--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -2,6 +2,13 @@
 name = "shard"
 version = "0.1.0"
 edition = "2024"
+description = "A minimal, content-addressed Minecraft launcher"
+license = "MIT"
+repository = "https://github.com/th0rgal/shard"
+homepage = "https://shard.thomas.md"
+keywords = ["minecraft", "launcher", "gaming", "modrinth", "curseforge"]
+categories = ["command-line-utilities", "games"]
+readme = "../README.md"
 
 [dependencies]
 anyhow = "1.0.100"

--- a/launcher/src/modrinth.rs
+++ b/launcher/src/modrinth.rs
@@ -4,7 +4,7 @@ use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use serde::{Deserialize, Serialize};
 
 const API_BASE: &str = "https://api.modrinth.com/v2";
-const USER_AGENT_VALUE: &str = "shard-launcher/1.0 (https://github.com/oraxen/shard)";
+const USER_AGENT_VALUE: &str = "shard-launcher/1.0 (https://github.com/th0rgal/shard)";
 
 /// Project types on Modrinth
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,46 @@
+# Package Manager Manifests
+
+This directory contains manifest templates for various package managers. After each release, update these manifests with the new version and SHA256 hashes from `SHA256SUMS.txt` in the release.
+
+## Status
+
+| Package Manager | Type | Status | Installation Command |
+|-----------------|------|--------|---------------------|
+| **Homebrew** | CLI + Desktop | Ready | `brew tap th0rgal/shard && brew install shard` |
+| **Winget** | Desktop | Template | `winget install Th0rgal.ShardLauncher` |
+| **Scoop** | CLI | Template | `scoop bucket add shard https://github.com/th0rgal/scoop-shard && scoop install shard` |
+| **AUR** | CLI + Desktop | Template | `yay -S shard` / `yay -S shard-launcher-bin` |
+| **Flathub** | Desktop | Template | `flatpak install flathub sh.shard.launcher` |
+
+## Updating After Release
+
+### Homebrew (th0rgal/homebrew-shard)
+
+1. Get SHA256 hashes from the release's `SHA256SUMS.txt`
+2. Update `Formula/shard.rb` and `Casks/shard-launcher.rb` with new version and hashes
+3. Push to the tap repository
+
+### Winget
+
+1. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)
+2. Copy `winget/` manifest to `manifests/t/Th0rgal/ShardLauncher/<version>/`
+3. Update version, URLs, and SHA256 hashes
+4. Submit PR
+
+### Scoop
+
+1. Create a `scoop-shard` bucket repository (similar to homebrew tap)
+2. Update `shard.json` with new version and hash
+3. Push to bucket repository
+
+### AUR
+
+1. Update PKGBUILDs with new version and hashes
+2. Use `makepkg --printsrcinfo > .SRCINFO` to regenerate
+3. Push to AUR git repositories
+
+### Flathub
+
+1. Fork [flathub/flathub](https://github.com/flathub/flathub) for initial submission
+2. Update manifest with new version and hash
+3. Submit PR

--- a/packaging/aur/shard-launcher-bin/PKGBUILD
+++ b/packaging/aur/shard-launcher-bin/PKGBUILD
@@ -1,0 +1,17 @@
+# Maintainer: Thomas Marchand <thomas@thomas.md>
+pkgname=shard-launcher-bin
+pkgver=0.1.1
+pkgrel=1
+pkgdesc="A minimal, content-addressed Minecraft launcher (Desktop App)"
+arch=('x86_64')
+url="https://shard.thomas.md"
+license=('MIT')
+depends=('webkit2gtk-4.1' 'libappindicator-gtk3')
+provides=('shard-launcher')
+conflicts=('shard-launcher')
+source=("https://github.com/th0rgal/shard/releases/download/v${pkgver}/shard-launcher-linux-x64.deb")
+sha256sums=('PLACEHOLDER_SHA256')
+
+package() {
+    bsdtar -xf data.tar.* -C "${pkgdir}/"
+}

--- a/packaging/aur/shard/PKGBUILD
+++ b/packaging/aur/shard/PKGBUILD
@@ -1,0 +1,16 @@
+# Maintainer: Thomas Marchand <thomas@thomas.md>
+pkgname=shard
+pkgver=0.1.1
+pkgrel=1
+pkgdesc="A minimal, content-addressed Minecraft launcher (CLI)"
+arch=('x86_64')
+url="https://shard.thomas.md"
+license=('MIT')
+depends=('gcc-libs')
+source=("https://github.com/th0rgal/shard/releases/download/v${pkgver}/shard-cli-linux-x64.tar.gz")
+sha256sums=('PLACEHOLDER_SHA256')
+
+package() {
+    install -Dm755 shard "${pkgdir}/usr/bin/shard"
+    install -Dm644 "${srcdir}/../LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE" || true
+}

--- a/packaging/flathub/sh.shard.launcher.metainfo.xml
+++ b/packaging/flathub/sh.shard.launcher.metainfo.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>sh.shard.launcher</id>
+  <name>Shard Launcher</name>
+  <summary>A minimal, content-addressed Minecraft launcher</summary>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <developer id="md.thomas">
+    <name>Thomas Marchand</name>
+  </developer>
+  <description>
+    <p>
+      Shard is a minimal, clean, CLI-first Minecraft launcher focused on stability,
+      reproducibility, and low duplication.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Content-addressed storage for mods and resource packs - no duplicates</li>
+      <li>Declarative profiles for reproducible setups</li>
+      <li>Support for Fabric, Forge, Quilt, and NeoForge</li>
+      <li>Modrinth and CurseForge integration</li>
+      <li>Multiple Microsoft account support</li>
+      <li>CLI-first design - everything can be scripted</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">sh.shard.launcher.desktop</launchable>
+  <url type="homepage">https://shard.thomas.md</url>
+  <url type="bugtracker">https://github.com/th0rgal/shard/issues</url>
+  <url type="vcs-browser">https://github.com/th0rgal/shard</url>
+  <categories>
+    <category>Game</category>
+    <category>Utility</category>
+  </categories>
+  <keywords>
+    <keyword>minecraft</keyword>
+    <keyword>launcher</keyword>
+    <keyword>modrinth</keyword>
+    <keyword>curseforge</keyword>
+    <keyword>fabric</keyword>
+    <keyword>forge</keyword>
+  </keywords>
+  <screenshots>
+    <!-- Add screenshots when available -->
+  </screenshots>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-chat">moderate</content_attribute>
+  </content_rating>
+  <releases>
+    <release version="0.1.1" date="2024-01-01">
+      <description>
+        <p>Initial release</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/packaging/flathub/sh.shard.launcher.yml
+++ b/packaging/flathub/sh.shard.launcher.yml
@@ -1,0 +1,56 @@
+id: sh.shard.launcher
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+command: shard-launcher
+
+finish-args:
+  # Display
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --share=ipc
+  # Network for downloads and auth
+  - --share=network
+  # Shard data directory
+  - --filesystem=~/.shard:create
+  # Java runtime access (for launching Minecraft)
+  - --filesystem=/usr/lib/jvm:ro
+  - --filesystem=~/.local/share/java:ro
+  # Minecraft directory (optional, for migration)
+  - --filesystem=~/.minecraft:ro
+  # Environment variable for Flatpak detection
+  - --env=FLATPAK=1
+  # System tray support (optional)
+  - --talk-name=org.kde.StatusNotifierWatcher
+
+modules:
+  - name: shard-launcher
+    buildsystem: simple
+    sources:
+      - type: file
+        url: https://github.com/th0rgal/shard/releases/download/v0.1.1/shard-launcher-linux-x64.deb
+        sha256: PLACEHOLDER_SHA256
+        dest-filename: shard-launcher.deb
+        only-arches:
+          - x86_64
+    build-commands:
+      # Extract deb package
+      - ar x shard-launcher.deb
+      - tar xf data.tar.*
+      # Install binary
+      - install -Dm755 usr/bin/shard-launcher /app/bin/shard-launcher
+      # Install desktop file
+      - install -Dm644 usr/share/applications/*.desktop /app/share/applications/sh.shard.launcher.desktop
+      # Install icons
+      - |
+        for size in 32 128 256 512; do
+          if [ -f "usr/share/icons/hicolor/${size}x${size}/apps/"*.png ]; then
+            install -Dm644 "usr/share/icons/hicolor/${size}x${size}/apps/"*.png \
+              "/app/share/icons/hicolor/${size}x${size}/apps/sh.shard.launcher.png"
+          fi
+        done
+    post-install:
+      # Fix desktop file for Flatpak
+      - sed -i 's|Exec=.*|Exec=shard-launcher|' /app/share/applications/sh.shard.launcher.desktop
+      - sed -i 's|Icon=.*|Icon=sh.shard.launcher|' /app/share/applications/sh.shard.launcher.desktop

--- a/packaging/scoop/shard.json
+++ b/packaging/scoop/shard.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.1.1",
+    "description": "A minimal, content-addressed Minecraft launcher (CLI)",
+    "homepage": "https://shard.thomas.md",
+    "license": "MIT",
+    "url": "https://github.com/th0rgal/shard/releases/download/v0.1.1/shard-cli-windows-x64.zip",
+    "hash": "PLACEHOLDER_SHA256",
+    "bin": "shard.exe",
+    "checkver": {
+        "github": "https://github.com/th0rgal/shard"
+    },
+    "autoupdate": {
+        "url": "https://github.com/th0rgal/shard/releases/download/v$version/shard-cli-windows-x64.zip"
+    }
+}

--- a/packaging/winget/Th0rgal.ShardLauncher.yaml
+++ b/packaging/winget/Th0rgal.ShardLauncher.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.6.0.schema.json
+PackageIdentifier: Th0rgal.ShardLauncher
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: Thomas Marchand
+PublisherUrl: https://thomas.md
+PublisherSupportUrl: https://github.com/th0rgal/shard/issues
+Author: Thomas Marchand
+PackageName: Shard Launcher
+PackageUrl: https://shard.thomas.md
+License: MIT
+LicenseUrl: https://github.com/th0rgal/shard/blob/main/LICENSE
+ShortDescription: A minimal, content-addressed Minecraft launcher
+Description: |-
+  Shard is a minimal, clean, CLI-first Minecraft launcher focused on stability,
+  reproducibility, and low duplication. It uses content-addressed storage to
+  deduplicate mods and resource packs across profiles.
+Tags:
+  - minecraft
+  - launcher
+  - gaming
+  - modrinth
+  - curseforge
+  - fabric
+  - forge
+Installers:
+  - Architecture: x64
+    InstallerType: msi
+    InstallerUrl: https://github.com/th0rgal/shard/releases/download/v0.1.1/shard-launcher-windows-x64.msi
+    InstallerSha256: PLACEHOLDER_SHA256
+ManifestType: singleton
+ManifestVersion: 1.6.0

--- a/web/app/opengraph-image.tsx
+++ b/web/app/opengraph-image.tsx
@@ -148,7 +148,7 @@ export default async function Image() {
             letterSpacing: "0.05em",
           }}
         >
-          shard.sh
+          shard.thomas.md
         </div>
       </div>
     ),

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = "https://shard.sh";
+  const baseUrl = "https://shard.thomas.md";
 
   // Static pages
   const staticPages = [

--- a/web/app/twitter-image.tsx
+++ b/web/app/twitter-image.tsx
@@ -148,7 +148,7 @@ export default async function Image() {
             letterSpacing: "0.05em",
           }}
         >
-          shard.sh
+          shard.thomas.md
         </div>
       </div>
     ),

--- a/web/components/JsonLd.tsx
+++ b/web/components/JsonLd.tsx
@@ -5,7 +5,7 @@ export function JsonLd() {
     name: "Shard Launcher",
     description:
       "A minimal, content-addressed Minecraft launcher focused on stability and reproducibility. One library. Infinite profiles.",
-    url: "https://shard.sh",
+    url: "https://shard.thomas.md",
     applicationCategory: "GameApplication",
     operatingSystem: ["macOS", "Windows", "Linux"],
     offers: {
@@ -18,7 +18,7 @@ export function JsonLd() {
       name: "Thomas Marchand",
       url: "https://thomas.md",
     },
-    downloadUrl: "https://shard.sh/docs/getting-started",
+    downloadUrl: "https://shard.thomas.md/docs/getting-started",
     keywords: [
       "Minecraft",
       "launcher",
@@ -43,9 +43,9 @@ export function JsonLd() {
     "@context": "https://schema.org",
     "@type": "Organization",
     name: "Shard",
-    url: "https://shard.sh",
-    logo: "https://shard.sh/icon-512.png",
-    sameAs: ["https://github.com/shard-org/shard"],
+    url: "https://shard.thomas.md",
+    logo: "https://shard.thomas.md/icon-512.png",
+    sameAs: ["https://github.com/th0rgal/shard"],
   };
 
   return (

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,6 +1,6 @@
-# Shard Launcher - https://shard.sh
+# Shard Launcher - https://shard.thomas.md
 User-agent: *
 Allow: /
 
 # Sitemap location
-Sitemap: https://shard.sh/sitemap.xml
+Sitemap: https://shard.thomas.md/sitemap.xml


### PR DESCRIPTION
## Summary

- Add CLI binary builds for all platforms (macOS ARM/Intel, Windows, Linux)
- Rename release artifacts for clarity (`shard-cli-*`, `shard-launcher-*`)
- Add SHA256SUMS.txt generation for checksums
- Create Homebrew tap at [th0rgal/homebrew-shard](https://github.com/th0rgal/homebrew-shard)
- Add package manager templates (Winget, Scoop, AUR, Flathub)
- Update URLs from shard.sh to shard.thomas.md
- Fix GitHub repo URL to th0rgal/shard
- Document release process in LLM context files

## Release Artifacts

| Component | Platforms | Formats |
|-----------|-----------|---------|
| CLI | macOS ARM/Intel, Windows, Linux | `.tar.gz` (Unix), `.zip` (Windows) |
| Desktop | macOS ARM/Intel | `.dmg` |
| Desktop | Windows | `.msi`, `-setup.exe` |
| Desktop | Linux | `.AppImage`, `.deb` |

## Package Managers

| Manager | Status | Installation |
|---------|--------|--------------|
| Homebrew | Ready | `brew tap th0rgal/shard && brew install shard` |
| Winget | Template | `winget install Th0rgal.ShardLauncher` |
| Scoop | Template | Bucket creation needed |
| AUR | Template | AUR submission needed |
| Flathub | Template | Flathub submission needed |

## Test plan

- [ ] Verify release workflow runs successfully on tag push
- [ ] Check artifact naming in GitHub releases
- [ ] Test Homebrew tap installation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Release automation overhaul**
> 
> - New GitHub Actions workflow builds CLI for macOS (arm64/x64), Windows, Linux and desktop app for all platforms; uploads clearly named artifacts (`shard-cli-*`, `shard-launcher-*`).
> - Generates `SHA256SUMS.txt` and drafts a GitHub Release with platform download tables and install snippets.
> 
> **Packaging + metadata**
> 
> - Adds package manager templates: Winget, Scoop, AUR, Flathub (with placeholder hashes); documents update steps in `packaging/README.md`.
> - Creates Homebrew tap link; adds package metadata in `launcher/Cargo.toml`.
> - Fixes Modrinth client `USER_AGENT` repo URL.
> 
> **Docs/website updates**
> 
> - Updates all site/SEO assets to `shard.thomas.md` (sitemap, robots.txt, JSON-LD, OpenGraph/Twitter images).
> - Adds release guidance to `.claude/CLAUDE.md`, `.codex/CODEX.md`, and `.cursor/rules/context.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07f5bb947c9f5b4e703a9f496b429a1c53afd025. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->