### PR TITLE
Fix blank white screen on Linux Wayland with NVIDIA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,7 +4083,7 @@ dependencies = [
 
 [[package]]
 name = "shard"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "atty",
@@ -4104,7 +4104,7 @@ dependencies = [
 
 [[package]]
 name = "shard_ui"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "reqwest",
  "serde",

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,5 +1,16 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Workaround for WebKitGTK DMA-BUF rendering issues on Wayland with NVIDIA GPUs.
+    // This must be set before Tauri/WebKit initializes.
+    // See: https://github.com/tauri-apps/tauri/issues/9394
+    #[cfg(target_os = "linux")]
+    {
+        // Only set if not already configured by the user
+        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+    }
+
     shard_ui::run();
 }


### PR DESCRIPTION
## Summary

Automatically disable WebKitGTK DMA-BUF renderer on Linux to prevent `EGL_BAD_PARAMETER` errors on Wayland with NVIDIA GPUs. This fixes the blank screen issue reported by users running Arch Linux with KDE Plasma and NVIDIA drivers.

The fix sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` before Tauri/WebKit initializes, respecting any user-configured value of the environment variable.

## Issue

Users reported a blank white screen when launching the AppImage on Linux with Wayland, with the error: `Could not create default EGL display: EGL_BAD_PARAMETER`

This is an upstream issue affecting WebKitGTK 2.42+ on Wayland with certain GPU/driver combinations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the desktop app renders correctly on Linux Wayland with NVIDIA by disabling the problematic WebKitGTK DMA-BUF renderer early in startup.
> 
> - Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` in `desktop/src-tauri/src/main.rs` on Linux before Tauri/WebKit initializes (respects existing env var)
> - Bump crate versions in `Cargo.lock`: `shard` and `shard_ui` to `0.1.6`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6b47aa414a58bb477e8fcca790f1d96c67e7b66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->