### PR TITLE
Fix Flathub workflow: use pip-installed flatpak-node-generator

### DIFF
--- a/.github/workflows/store-publish.yml
+++ b/.github/workflows/store-publish.yml
@@ -371,6 +371,8 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: |
           pip install aiohttp toml tomlkit
+          # Install flatpak-node-generator (it's now a Python package, not a standalone script)
+          pip install "git+https://github.com/flatpak/flatpak-builder-tools.git#subdirectory=node"
 
       - name: Collect release info
         if: steps.check.outputs.skip != 'true'
@@ -411,10 +413,8 @@ jobs:
           cd desktop
           # Generate package-lock.json from package.json (npm format for flatpak-node-generator)
           npm install --package-lock-only --ignore-scripts
-          # Generate node sources
-          python3 /tmp/flatpak-builder-tools/node/flatpak-node-generator.py npm \
-            package-lock.json \
-            -o /tmp/node-sources.json
+          # Generate node sources using the installed flatpak-node-generator package
+          flatpak-node-generator npm package-lock.json -o /tmp/node-sources.json
 
       - name: Clone and update Flathub repo
         if: steps.check.outputs.skip != 'true'


### PR DESCRIPTION
The flatpak-node-generator has been restructured from a standalone script to a Python package. Install it via pip and run it as a command instead of calling the script directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the Flathub workflow to the pip-installed `flatpak-node-generator` CLI instead of invoking the script from the cloned repo.
> 
> - Install `flatpak-node-generator` via pip (`git+https://github.com/flatpak/flatpak-builder-tools.git#subdirectory=node`)
> - Replace `python .../node/flatpak-node-generator.py` with `flatpak-node-generator npm package-lock.json -o /tmp/node-sources.json` in the node sources generation step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6f5a09c9a4d2dd83dbbf4ee887cf1f70c13df2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->