### PR TITLE
Add automatic Java download from Adoptium

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,7 +4138,7 @@ dependencies = [
 
 [[package]]
 name = "shard"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "atty",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "shard_ui"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "reqwest",
  "serde",

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -74,6 +74,12 @@ pub fn run() {
             commands::validate_java_path_cmd,
             commands::get_required_java_version_cmd,
             commands::check_java_compatibility_cmd,
+            // Java download commands
+            commands::fetch_adoptium_release_cmd,
+            commands::download_java_cmd,
+            commands::find_compatible_java_cmd,
+            commands::get_managed_java_cmd,
+            commands::list_managed_runtimes_cmd,
             // Library commands
             commands::library_list_items_cmd,
             commands::library_get_item_cmd,

--- a/desktop/src/components/modals/JavaDownloadModal.tsx
+++ b/desktop/src/components/modals/JavaDownloadModal.tsx
@@ -1,0 +1,191 @@
+import { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { Modal } from "../Modal";
+import { useAppStore } from "../../store";
+
+interface JavaDownloadModalProps {
+  open: boolean;
+  onClose: () => void;
+  javaMajor: number;
+  mcVersion: string;
+  onSuccess: (javaPath: string) => void;
+}
+
+interface AdoptiumRelease {
+  version: string;
+  major: number;
+  download_url: string;
+  filename: string;
+  size: number;
+  checksum: string | null;
+}
+
+interface DownloadProgress {
+  downloaded: number;
+  total: number;
+  percentage: number;
+}
+
+export function JavaDownloadModal({ open, onClose, javaMajor, mcVersion, onSuccess }: JavaDownloadModalProps) {
+  const { notify } = useAppStore();
+  const [stage, setStage] = useState<"confirm" | "downloading" | "extracting" | "done">("confirm");
+  const [releaseInfo, setReleaseInfo] = useState<AdoptiumRelease | null>(null);
+  const [progress, setProgress] = useState<DownloadProgress>({ downloaded: 0, total: 0, percentage: 0 });
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (open) {
+      setStage("confirm");
+      setReleaseInfo(null);
+      setProgress({ downloaded: 0, total: 0, percentage: 0 });
+      setError(null);
+      // Fetch release info
+      fetchReleaseInfo();
+    }
+  }, [open, javaMajor]);
+
+  // Listen for progress events
+  useEffect(() => {
+    if (!open) return;
+
+    const unlisten = listen<DownloadProgress>("java-download-progress", (event) => {
+      setProgress(event.payload);
+    });
+
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [open]);
+
+  const fetchReleaseInfo = async () => {
+    try {
+      const info = await invoke<AdoptiumRelease>("fetch_adoptium_release_cmd", { javaMajor });
+      setReleaseInfo(info);
+    } catch (err) {
+      setError(`Failed to fetch Java info: ${err}`);
+    }
+  };
+
+  const handleDownload = async () => {
+    setStage("downloading");
+    setError(null);
+
+    try {
+      const javaPath = await invoke<string>("download_java_cmd", { javaMajor });
+      setStage("done");
+      setTimeout(() => {
+        onSuccess(javaPath);
+        onClose();
+      }, 1000);
+    } catch (err) {
+      setError(`Download failed: ${err}`);
+      setStage("confirm");
+    }
+  };
+
+  const formatSize = (bytes: number): string => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+  };
+
+  // Don't allow closing during download
+  const handleClose = stage === "downloading" ? () => {} : onClose;
+
+  return (
+    <Modal open={open} onClose={handleClose} title="Java Required">
+      <div className="java-download-modal">
+        {error && (
+          <div className="java-download-error">
+            {error}
+          </div>
+        )}
+
+        {stage === "confirm" && (
+          <>
+            <p className="java-download-desc">
+              Minecraft {mcVersion} requires <strong>Java {javaMajor}</strong> which is not installed on your system.
+            </p>
+            <p className="java-download-desc">
+              Would you like to download and install it automatically from Eclipse Adoptium (Temurin)?
+            </p>
+
+            {releaseInfo && (
+              <div className="java-download-info">
+                <div className="java-download-info-row">
+                  <span className="java-download-info-label">Version</span>
+                  <span className="java-download-info-value">{releaseInfo.version}</span>
+                </div>
+                <div className="java-download-info-row">
+                  <span className="java-download-info-label">Size</span>
+                  <span className="java-download-info-value">{formatSize(releaseInfo.size)}</span>
+                </div>
+              </div>
+            )}
+
+            <div className="java-download-actions">
+              <button className="btn btn-secondary" onClick={onClose}>
+                Cancel
+              </button>
+              <button
+                className="btn btn-primary"
+                onClick={handleDownload}
+                disabled={!releaseInfo}
+              >
+                {releaseInfo ? "Download Java" : "Loading..."}
+              </button>
+            </div>
+          </>
+        )}
+
+        {stage === "downloading" && (
+          <>
+            <p className="java-download-desc">
+              Downloading Java {javaMajor}...
+            </p>
+
+            <div className="java-download-progress">
+              <div className="java-download-progress-bar">
+                <div
+                  className="java-download-progress-fill"
+                  style={{ width: `${progress.percentage}%` }}
+                />
+              </div>
+              <div className="java-download-progress-text">
+                {formatSize(progress.downloaded)} / {formatSize(progress.total)} ({progress.percentage}%)
+              </div>
+            </div>
+
+            <p className="java-download-hint">
+              Please wait, this may take a few minutes...
+            </p>
+          </>
+        )}
+
+        {stage === "extracting" && (
+          <>
+            <p className="java-download-desc">
+              Extracting Java {javaMajor}...
+            </p>
+            <div className="java-download-spinner" />
+          </>
+        )}
+
+        {stage === "done" && (
+          <>
+            <div className="java-download-success">
+              <svg width="48" height="48" viewBox="0 0 48 48" fill="none">
+                <circle cx="24" cy="24" r="20" stroke="var(--accent-success)" strokeWidth="3" />
+                <path d="M16 24l6 6 12-12" stroke="var(--accent-success)" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              <p>Java {javaMajor} installed successfully!</p>
+            </div>
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/desktop/src/components/modals/index.ts
+++ b/desktop/src/components/modals/index.ts
@@ -7,3 +7,4 @@ export { DeviceCodeModal } from "./DeviceCodeModal";
 export { ProfileJsonModal } from "./ProfileJsonModal";
 export { AccountDetailsModal } from "./AccountDetailsModal";
 export { EditVersionModal } from "./EditVersionModal";
+export { JavaDownloadModal } from "./JavaDownloadModal";

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -3002,6 +3002,136 @@ a {
 }
 
 /* =============================================================================
+   JAVA DOWNLOAD MODAL
+   ============================================================================= */
+.java-download-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.java-download-desc {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.java-download-desc strong {
+  color: var(--text-primary);
+}
+
+.java-download-error {
+  background: rgba(248, 113, 113, 0.1);
+  border: 1px solid rgba(248, 113, 113, 0.3);
+  border-radius: 10px;
+  padding: 12px 16px;
+  color: var(--accent-danger);
+  font-size: 13px;
+}
+
+.java-download-info {
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.java-download-info-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 0;
+}
+
+.java-download-info-row:not(:last-child) {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.java-download-info-label {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.java-download-info-value {
+  font-size: 13px;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.java-download-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.java-download-actions .btn {
+  flex: 1;
+}
+
+.java-download-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.java-download-progress-bar {
+  height: 8px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.java-download-progress-fill {
+  height: 100%;
+  background: var(--accent-primary);
+  border-radius: 4px;
+  transition: width 0.2s ease;
+}
+
+.java-download-progress-text {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.java-download-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.java-download-success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 24px 0;
+}
+
+.java-download-success p {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--accent-success);
+}
+
+.java-download-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid rgba(255, 255, 255, 0.1);
+  border-top-color: var(--accent-primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 16px auto;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* =============================================================================
    JSON VIEWER
    ============================================================================= */
 .json-viewer {

--- a/launcher/src/paths.rs
+++ b/launcher/src/paths.rs
@@ -21,6 +21,7 @@ pub struct Paths {
     pub config: PathBuf,
     pub library_db: PathBuf,
     pub profile_organization: PathBuf,
+    pub java_runtimes: PathBuf,
 }
 
 impl Paths {
@@ -56,6 +57,7 @@ impl Paths {
         let config = base.join("config.json");
         let library_db = base.join("library.db");
         let profile_organization = base.join("profile-organization.json");
+        let java_runtimes = base.join("java");
 
         Ok(Self {
             store_mods,
@@ -75,6 +77,7 @@ impl Paths {
             config,
             library_db,
             profile_organization,
+            java_runtimes,
         })
     }
 
@@ -102,6 +105,8 @@ impl Paths {
             .context("failed to create minecraft assets objects directory")?;
         std::fs::create_dir_all(&self.minecraft_assets_indexes)
             .context("failed to create minecraft assets indexes directory")?;
+        std::fs::create_dir_all(&self.java_runtimes)
+            .context("failed to create java runtimes directory")?;
         Ok(())
     }
 
@@ -168,5 +173,9 @@ impl Paths {
 
     pub fn cache_manifest(&self, name: &str) -> PathBuf {
         self.cache_manifests.join(name)
+    }
+
+    pub fn java_runtime_dir(&self, name: &str) -> PathBuf {
+        self.java_runtimes.join(name)
     }
 }


### PR DESCRIPTION
## Summary
- Automatically detect when Java is missing before launching Minecraft
- Prompt user to download Java from Eclipse Adoptium (Temurin)
- Download with progress reporting and extract to `~/.shard/java/`
- Managed Java runtimes are checked first, then fallback to system Java

## Features
- Fetches correct Java version for the Minecraft version (Java 21 for 1.20.5+, Java 17 for 1.18+, etc.)
- Automatically detects OS and architecture for correct download
- Progress bar during download
- Clean extraction to managed directory
- Works on Windows, macOS, and Linux

## Files changed
- `launcher/src/java.rs` - Download and extraction logic
- `launcher/src/paths.rs` - Added `java_runtimes` path
- `desktop/src-tauri/src/commands.rs` - Tauri commands for Java management
- `desktop/src/components/modals/JavaDownloadModal.tsx` - Download UI
- `desktop/src/App.tsx` - Integration into launch flow
- `desktop/src/styles.css` - Modal styles

## Test plan
- [ ] Test on Windows: launch profile without Java installed
- [ ] Test on macOS: launch profile without compatible Java
- [ ] Test on Linux: launch profile and verify Java download
- [ ] Verify managed Java is used on subsequent launches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds first-class Java management and auto-install to unblock launches without a compatible JRE.
> 
> - **Backend (launcher)**: Implements `fetch_adoptium_release`, `download_and_install_java` (with progress), zip/tar.gz extraction, and OS/arch detection; adds managed runtime helpers (`get_managed_java`, `list_managed_runtimes`, `find_compatible_java`) and stores under `~/.shard/java/`. Updates `Paths` with `java_runtimes` and ensures directory creation.
> - **Tauri commands**: Adds `fetch_adoptium_release_cmd`, `download_java_cmd` (emits `java-download-progress`), `find_compatible_java_cmd`, `get_managed_java_cmd`, `list_managed_runtimes_cmd`.
> - **UI**: New `JavaDownloadModal` with size/info and progress; `App.tsx` checks for compatible Java before launching, prompts install, then retries launch; adds styles for the modal.
> - **Misc**: Bumps `shard` and `shard_ui` to `0.1.12` in `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 691be2f087ac945323d7ef93181d1195e2459ff7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->