### PR TITLE
Fix Linux startup, window chrome, and Windows content materialization

### DIFF
--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -356,7 +356,7 @@ pub fn remove_account_cmd(id: String) -> Result<(), String> {
         // Save accounts first, then delete tokens to avoid inconsistent state
         save_accounts(&paths, &accounts).map_err(|e| e.to_string())?;
         for uuid in &removed_uuids {
-            delete_account_tokens(uuid).map_err(|e| e.to_string())?;
+            delete_account_tokens(&paths, uuid).map_err(|e| e.to_string())?;
         }
         Ok(())
     } else {

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -33,7 +33,19 @@ use shard::template::{Template, list_templates, load_template, init_builtin_temp
 use shard::updates::{StorageStats, UpdateCheckResult, get_storage_stats, check_all_updates, check_profile_updates, set_content_pinned, set_content_enabled, apply_update};
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::{AppHandle, Emitter};
+
+static CUSTOM_CHROME_ENABLED: AtomicBool = AtomicBool::new(false);
+
+pub fn set_custom_chrome_enabled(enabled: bool) {
+    CUSTOM_CHROME_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+#[tauri::command]
+pub fn custom_chrome_enabled_cmd() -> bool {
+    CUSTOM_CHROME_ENABLED.load(Ordering::Relaxed)
+}
 
 #[derive(Serialize)]
 pub struct DiffResult {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -3,46 +3,19 @@ mod commands;
 #[cfg(target_os = "linux")]
 use tauri::Manager;
 
-/// Check if the current Linux desktop environment uses client-side decorations (CSDs).
-/// Returns true for GNOME and GNOME-based environments, false otherwise.
-#[cfg(target_os = "linux")]
-fn is_csd_desktop() -> bool {
-    // Check XDG_CURRENT_DESKTOP which can contain multiple values separated by ":"
-    if let Ok(desktop) = std::env::var("XDG_CURRENT_DESKTOP") {
-        let desktop_lower = desktop.to_lowercase();
-        // GNOME and GNOME-based environments use CSDs
-        if desktop_lower.contains("gnome")
-            || desktop_lower.contains("unity")
-            || desktop_lower.contains("pantheon")
-            || desktop_lower.contains("budgie")
-        {
-            return true;
-        }
-    }
-
-    // Fallback: check for GNOME session ID
-    if std::env::var("GNOME_DESKTOP_SESSION_ID").is_ok() {
-        return true;
-    }
-
-    false
-}
-
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .setup(|app| {
             #[cfg(desktop)]
-            let _ = app.handle().plugin(tauri_plugin_updater::Builder::new().build());
+            let _ = app
+                .handle()
+                .plugin(tauri_plugin_updater::Builder::new().build());
 
-            // On Linux with non-GNOME desktops, disable native window decorations
-            // to prevent double title bars. The app has its own custom title bar.
             #[cfg(target_os = "linux")]
             {
-                if !is_csd_desktop() {
-                    if let Some(window) = app.get_webview_window("main") {
-                        let _ = window.set_decorations(false);
-                    }
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.set_decorations(false);
                 }
             }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -15,7 +15,7 @@ pub fn run() {
             #[cfg(target_os = "linux")]
             {
                 if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.set_decorations(false);
+                    commands::set_custom_chrome_enabled(window.set_decorations(false).is_ok());
                 }
             }
 
@@ -118,6 +118,7 @@ pub fn run() {
             commands::purge_unused_items_cmd,
             commands::get_auto_update_enabled_cmd,
             commands::set_auto_update_enabled_cmd,
+            commands::custom_chrome_enabled_cmd,
             // Update checking commands
             commands::check_all_updates_cmd,
             commands::check_profile_updates_cmd,

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
             std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
 
-        if std::env::var("APPIMAGE").is_ok() && std::env::var("LD_PRELOAD").is_err() {
+        if std::env::var("APPIMAGE").is_ok() {
             for path in [
                 "/usr/lib64/libwayland-client.so.0",
                 "/usr/lib64/libwayland-client.so",
@@ -17,7 +17,17 @@ fn main() {
                 "/usr/lib/x86_64-linux-gnu/libwayland-client.so",
             ] {
                 if std::path::Path::new(path).exists() {
-                    std::env::set_var("LD_PRELOAD", path);
+                    let preload = match std::env::var("LD_PRELOAD") {
+                        Ok(existing) if !existing.is_empty() => {
+                            if existing.split(':').any(|entry| entry == path) {
+                                existing
+                            } else {
+                                format!("{existing}:{path}")
+                            }
+                        }
+                        _ => path.to_string(),
+                    };
+                    std::env::set_var("LD_PRELOAD", preload);
                     break;
                 }
             }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,23 +1,26 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    // Workaround for WebKitGTK DMA-BUF rendering issues on Wayland with NVIDIA GPUs.
-    // This must be set before Tauri/WebKit initializes.
-    // See: https://github.com/tauri-apps/tauri/issues/9394
     #[cfg(target_os = "linux")]
     {
-        // Only set if not already configured by the user
         if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
             std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
 
-        // On some Wayland setups the AppImage fails to create an EGL display.
-        // Fallback to X11 when running from AppImage unless the user overrides.
-        let is_wayland = std::env::var("WAYLAND_DISPLAY").is_ok()
-            || matches!(std::env::var("XDG_SESSION_TYPE"), Ok(session) if session == "wayland");
-        let is_appimage = std::env::var("APPIMAGE").is_ok();
-        if is_appimage && is_wayland && std::env::var("GDK_BACKEND").is_err() {
-            std::env::set_var("GDK_BACKEND", "x11");
+        if std::env::var("APPIMAGE").is_ok() && std::env::var("LD_PRELOAD").is_err() {
+            for path in [
+                "/usr/lib64/libwayland-client.so.0",
+                "/usr/lib64/libwayland-client.so",
+                "/usr/lib/libwayland-client.so.0",
+                "/usr/lib/libwayland-client.so",
+                "/usr/lib/x86_64-linux-gnu/libwayland-client.so.0",
+                "/usr/lib/x86_64-linux-gnu/libwayland-client.so",
+            ] {
+                if std::path::Path::new(path).exists() {
+                    std::env::set_var("LD_PRELOAD", path);
+                    break;
+                }
+            }
         }
     }
 

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -79,6 +79,7 @@ function App() {
   const isOnline = useOnline();
   const [launchHidden, setLaunchHidden] = useState(false);
   const [currentPlatform, setCurrentPlatform] = useState<string>("");
+  const [customChromeEnabled, setCustomChromeEnabled] = useState(false);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const updateCheckRef = useRef(false);
@@ -91,7 +92,18 @@ function App() {
 
   // Detect platform for platform-specific styling
   useEffect(() => {
-    setCurrentPlatform(platform());
+    const detectedPlatform = platform();
+    setCurrentPlatform(detectedPlatform);
+
+    if (detectedPlatform === "windows") {
+      setCustomChromeEnabled(true);
+    } else if (detectedPlatform === "linux") {
+      invoke<boolean>("custom_chrome_enabled_cmd")
+        .then(setCustomChromeEnabled)
+        .catch(() => setCustomChromeEnabled(false));
+    } else {
+      setCustomChromeEnabled(false);
+    }
   }, []);
 
   // Content modal state
@@ -224,6 +236,8 @@ function App() {
 
   // Window dragging
   useEffect(() => {
+    if (!customChromeEnabled) return;
+
     const handleMouseDown = async (e: MouseEvent) => {
       if (e.button !== 0) return;
 
@@ -255,7 +269,7 @@ function App() {
 
     document.addEventListener("mousedown", handleMouseDown);
     return () => document.removeEventListener("mousedown", handleMouseDown);
-  }, []);
+  }, [customChromeEnabled]);
 
   // Handlers
   const handleCreateProfile = useCallback(async (form: CreateProfileForm) => {
@@ -413,10 +427,13 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <div className={clsx("app-root", debugDrag && "debug-drag")} data-platform={currentPlatform}>
+      <div
+        className={clsx("app-root", debugDrag && "debug-drag")}
+        data-platform={customChromeEnabled ? currentPlatform : undefined}
+      >
         <div className="titlebar-drag-region" />
         <div className="sidebar-titlebar-bg" />
-        <WindowControls />
+        <WindowControls enabled={customChromeEnabled} />
 
         {!isOnline && (
           <div

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -228,7 +228,7 @@ function App() {
       if (e.button !== 0) return;
 
       const target = e.target as HTMLElement;
-      const dragRegion = target.closest(".titlebar-drag-region, [data-tauri-drag-region='true'], .drag-region");
+      const dragRegion = target.closest(".titlebar-drag-region, [data-tauri-drag-region='true']");
       if (!dragRegion) return;
       if (target.closest(NO_DRAG_SELECTOR)) return;
       // Don't interfere with HTML5 drag operations (e.g., sidebar profile reordering)
@@ -434,7 +434,7 @@ function App() {
           />
         )}
 
-        <div className="app-layout drag-region">
+        <div className="app-layout">
           <Sidebar
             onCreateProfile={() => setActiveModal("create")}
             onCloneProfile={() => setActiveModal("clone")}

--- a/desktop/src/components/WindowControls.tsx
+++ b/desktop/src/components/WindowControls.tsx
@@ -1,18 +1,15 @@
 import { useEffect, useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { platform } from "@tauri-apps/plugin-os";
 
-export function WindowControls() {
-  const [showControls, setShowControls] = useState(false);
+type WindowControlsProps = {
+  enabled: boolean;
+};
+
+export function WindowControls({ enabled }: WindowControlsProps) {
   const [isMaximized, setIsMaximized] = useState(false);
 
   useEffect(() => {
-    const currentPlatform = platform();
-    setShowControls(currentPlatform === "windows" || currentPlatform === "linux");
-  }, []);
-
-  useEffect(() => {
-    if (!showControls) return;
+    if (!enabled) return;
 
     const win = getCurrentWindow();
 
@@ -27,9 +24,9 @@ export function WindowControls() {
     return () => {
       unlisten.then((fn) => fn());
     };
-  }, [showControls]);
+  }, [enabled]);
 
-  if (!showControls) return null;
+  if (!enabled) return null;
 
   const win = getCurrentWindow();
 

--- a/desktop/src/components/WindowControls.tsx
+++ b/desktop/src/components/WindowControls.tsx
@@ -3,15 +3,16 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { platform } from "@tauri-apps/plugin-os";
 
 export function WindowControls() {
-  const [isWindows, setIsWindows] = useState(false);
+  const [showControls, setShowControls] = useState(false);
   const [isMaximized, setIsMaximized] = useState(false);
 
   useEffect(() => {
-    setIsWindows(platform() === "windows");
+    const currentPlatform = platform();
+    setShowControls(currentPlatform === "windows" || currentPlatform === "linux");
   }, []);
 
   useEffect(() => {
-    if (!isWindows) return;
+    if (!showControls) return;
 
     const win = getCurrentWindow();
 
@@ -26,9 +27,9 @@ export function WindowControls() {
     return () => {
       unlisten.then((fn) => fn());
     };
-  }, [isWindows]);
+  }, [showControls]);
 
-  if (!isWindows) return null;
+  if (!showControls) return null;
 
   const win = getCurrentWindow();
 

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -235,7 +235,7 @@ a {
 }
 
 /* =============================================================================
-   WINDOWS WINDOW CONTROLS (minimize, maximize, close)
+   WINDOW CONTROLS
    ============================================================================= */
 .window-controls {
   position: fixed;

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -304,8 +304,9 @@ a {
   padding-top: 52px; /* Space for macOS traffic lights */
 }
 
-/* Windows: reduce top padding since window controls are on the right */
-[data-platform="windows"] .sidebar {
+/* Right-side window controls do not need traffic-light spacing */
+[data-platform="windows"] .sidebar,
+[data-platform="linux"] .sidebar {
   padding-top: 16px;
 }
 

--- a/launcher/src/instance.rs
+++ b/launcher/src/instance.rs
@@ -94,24 +94,128 @@ fn populate_dir(
 }
 
 fn link_or_copy(src: &Path, dst: &Path) -> Result<()> {
-    if let Err(err) = symlink_file(src, dst) {
-        fs::copy(src, dst).with_context(|| {
-            format!(
-                "failed to copy {} to {} after symlink error: {err}",
-                src.display(),
-                dst.display()
-            )
-        })?;
+    #[cfg(windows)]
+    {
+        fs::copy(src, dst)
+            .with_context(|| format!("failed to copy {} to {}", src.display(), dst.display()))?;
+        return Ok(());
     }
-    Ok(())
+
+    #[cfg(not(windows))]
+    {
+        if let Err(err) = symlink_file(src, dst) {
+            fs::copy(src, dst).with_context(|| {
+                format!(
+                    "failed to copy {} to {} after symlink error: {err}",
+                    src.display(),
+                    dst.display()
+                )
+            })?;
+        }
+        Ok(())
+    }
 }
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 fn symlink_file(src: &Path, dst: &Path) -> std::io::Result<()> {
     std::os::unix::fs::symlink(src, dst)
 }
 
-#[cfg(windows)]
-fn symlink_file(src: &Path, dst: &Path) -> std::io::Result<()> {
-    std::os::windows::fs::symlink_file(src, dst)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profile::{Files, Runtime};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_paths() -> Paths {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let base = std::env::temp_dir().join(format!("shard-instance-test-{unique}"));
+
+        Paths {
+            store_mods: base.join("store").join("mods").join("sha256"),
+            store_resourcepacks: base.join("store").join("resourcepacks").join("sha256"),
+            store_shaderpacks: base.join("store").join("shaderpacks").join("sha256"),
+            store_skins: base.join("store").join("skins").join("sha256"),
+            profiles: base.join("profiles"),
+            instances: base.join("instances"),
+            cache_downloads: base.join("caches").join("downloads"),
+            cache_manifests: base.join("caches").join("manifests"),
+            logs: base.join("logs"),
+            minecraft_versions: base.join("minecraft").join("versions"),
+            minecraft_libraries: base.join("minecraft").join("libraries"),
+            minecraft_assets_objects: base.join("minecraft").join("assets").join("objects"),
+            minecraft_assets_indexes: base.join("minecraft").join("assets").join("indexes"),
+            accounts: base.join("accounts.json"),
+            tokens: base.join("tokens.json"),
+            secrets: base.join("secrets.json"),
+            config: base.join("config.json"),
+            library_db: base.join("library.db"),
+            profile_organization: base.join("profile-organization.json"),
+            java_runtimes: base.join("java"),
+        }
+    }
+
+    fn content(name: &str, hash: &str, file_name: &str, enabled: bool) -> ContentRef {
+        ContentRef {
+            name: name.to_string(),
+            hash: format!("sha256:{hash}"),
+            version: None,
+            source: None,
+            file_name: Some(file_name.to_string()),
+            platform: None,
+            project_id: None,
+            version_id: None,
+            enabled,
+            pinned: false,
+        }
+    }
+
+    #[test]
+    fn materializes_enabled_profile_content() {
+        let paths = test_paths();
+        paths.ensure().unwrap();
+        fs::write(paths.store_mod_path("modhash"), "mod bytes").unwrap();
+        fs::write(paths.store_resourcepack_path("packhash"), "pack bytes").unwrap();
+        fs::write(paths.store_shaderpack_path("shaderhash"), "shader bytes").unwrap();
+
+        let profile = Profile {
+            id: "profile".to_string(),
+            mc_version: "1.21.4".to_string(),
+            loader: None,
+            mods: vec![content("Mod", "modhash", "mod.jar", true)],
+            resourcepacks: vec![content("Pack", "packhash", "pack.zip", true)],
+            shaderpacks: vec![
+                content("Shader", "shaderhash", "shader.zip", true),
+                content("Disabled", "missinghash", "disabled.zip", false),
+            ],
+            runtime: Runtime::default(),
+            files: Files::default(),
+        };
+
+        let instance_dir = materialize_instance(&paths, &profile).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(instance_dir.join("mods").join("mod.jar")).unwrap(),
+            "mod bytes"
+        );
+        assert_eq!(
+            fs::read_to_string(instance_dir.join("resourcepacks").join("pack.zip")).unwrap(),
+            "pack bytes"
+        );
+        assert_eq!(
+            fs::read_to_string(instance_dir.join("shaderpacks").join("shader.zip")).unwrap(),
+            "shader bytes"
+        );
+        assert!(
+            !instance_dir
+                .join("shaderpacks")
+                .join("disabled.zip")
+                .exists()
+        );
+
+        let _ = fs::remove_dir_all(paths.instances.parent().unwrap());
+    }
 }


### PR DESCRIPTION
## Summary
- fix Linux titlebar behavior by showing custom controls on Linux and limiting drag handling to the titlebar region
- improve Linux AppImage startup by avoiding forced X11 fallback and inheriting the system Wayland client library for WebKit child processes when available
- fix Windows instance materialization by copying profile content instead of creating symlinks
- fix desktop account removal to pass the configured paths when deleting account tokens

## Issues
Fixes #11
Fixes #20
Fixes #34
Fixes #37

## Verification
- `npm run build`
- `CARGO_TARGET_DIR=/workspaces/mission-9b3a1235/shard-target cargo test -p shard`
- `CARGO_TARGET_DIR=/workspaces/mission-9b3a1235/shard-target cargo check -p shard_ui`
- Clean `SHARD_HOME` CLI smoke test: list profiles, create a profile, list profiles again
- Local Tauri dev run under Xvfb: launcher window opened, Linux controls were visible, and the New profile modal opened

Note: #8 is intentionally not included here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes platform-specific startup behavior (Linux AppImage env handling and window decorations) and alters how instance content is materialized on Windows, which can affect launch reliability and file I/O behavior.
> 
> **Overview**
> Fixes cross-platform desktop reliability issues by **standardizing custom window chrome enablement** and exposing it to the frontend via `custom_chrome_enabled_cmd`, so Linux can show custom controls only when decorations were successfully disabled and dragging is limited to the titlebar region.
> 
> Improves **Linux AppImage startup** by removing the forced X11 fallback and instead conditionally extending `LD_PRELOAD` with an available system `libwayland-client` to help WebKit child processes.
> 
> Fixes **Windows instance materialization** by copying profile content instead of attempting symlinks, and corrects account removal to pass `Paths` into `delete_account_tokens` to ensure token cleanup uses the configured data location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23947271f985b7e351a0be770fbd9d766781b1b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->