### PR TITLE
Add account check and Java 26 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ shard store install <profile> <platform> <project-id>
 shard account add                             # Add Microsoft account
 shard account list                            # List accounts
 shard account use <username>                  # Set active account
+shard account check                           # Validate/refresh active account tokens
 shard account remove <username>               # Remove account
 ```
 

--- a/launcher/src/java.rs
+++ b/launcher/src/java.rs
@@ -46,6 +46,7 @@ pub struct JavaRequirement {
 /// Known Minecraft version to Java requirements.
 /// Listed from newest to oldest.
 const MC_JAVA_REQUIREMENTS: &[JavaRequirement] = &[
+    JavaRequirement { mc_version_min: "26.1", java_major: 25 },
     JavaRequirement { mc_version_min: "1.20.5", java_major: 21 },
     JavaRequirement { mc_version_min: "1.18", java_major: 17 },
     JavaRequirement { mc_version_min: "1.17", java_major: 16 },
@@ -919,6 +920,8 @@ mod tests {
 
     #[test]
     fn test_get_required_java_version() {
+        assert_eq!(get_required_java_version("26.1.2"), 25);
+        assert_eq!(get_required_java_version("26.1"), 25);
         assert_eq!(get_required_java_version("1.20.6"), 21);
         assert_eq!(get_required_java_version("1.20.5"), 21);
         assert_eq!(get_required_java_version("1.20.4"), 17);
@@ -930,6 +933,8 @@ mod tests {
 
     #[test]
     fn test_is_java_compatible() {
+        assert!(is_java_compatible(25, "26.1.2"));
+        assert!(!is_java_compatible(21, "26.1.2"));
         assert!(is_java_compatible(21, "1.20.6"));
         assert!(is_java_compatible(21, "1.18"));
         assert!(!is_java_compatible(17, "1.20.6"));
@@ -946,6 +951,8 @@ mod tests {
         assert_eq!(compare_mc_versions("1.20.6", "1.20.5"), 1);
         assert_eq!(compare_mc_versions("1.20.4", "1.20.5"), -1);
         assert_eq!(compare_mc_versions("1.21", "1.20.5"), 1);
+        assert_eq!(compare_mc_versions("26.1.2", "1.21.11"), 1);
+        assert_eq!(compare_mc_versions("26.1.2", "26.1"), 1);
         assert_eq!(compare_mc_versions("1.18", "1.17"), 1);
     }
 

--- a/launcher/src/java.rs
+++ b/launcher/src/java.rs
@@ -46,11 +46,26 @@ pub struct JavaRequirement {
 /// Known Minecraft version to Java requirements.
 /// Listed from newest to oldest.
 const MC_JAVA_REQUIREMENTS: &[JavaRequirement] = &[
-    JavaRequirement { mc_version_min: "26.1", java_major: 25 },
-    JavaRequirement { mc_version_min: "1.20.5", java_major: 21 },
-    JavaRequirement { mc_version_min: "1.18", java_major: 17 },
-    JavaRequirement { mc_version_min: "1.17", java_major: 16 },
-    JavaRequirement { mc_version_min: "1.0", java_major: 8 },
+    JavaRequirement {
+        mc_version_min: "26.1",
+        java_major: 25,
+    },
+    JavaRequirement {
+        mc_version_min: "1.20.5",
+        java_major: 21,
+    },
+    JavaRequirement {
+        mc_version_min: "1.18",
+        java_major: 17,
+    },
+    JavaRequirement {
+        mc_version_min: "1.17",
+        java_major: 16,
+    },
+    JavaRequirement {
+        mc_version_min: "1.0",
+        java_major: 8,
+    },
 ];
 
 /// Detect all Java installations on the system.
@@ -480,6 +495,17 @@ fn is_snapshot_version(version: &str) -> bool {
 fn compare_mc_versions(a: &str, b: &str) -> i32 {
     // Handle snapshot versions - treat them as "latest" (very high version)
     // This ensures snapshots get modern Java requirements
+    let parse_numeric_part = |part: Option<&&str>| -> u32 {
+        part.map(|p| {
+            p.chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect::<String>()
+                .parse()
+                .unwrap_or(0)
+        })
+        .unwrap_or(0)
+    };
+
     let parse = |s: &str| -> (u32, u32, u32) {
         if is_snapshot_version(s) {
             // Extract year from snapshot (e.g., "24" from "24w14a")
@@ -493,9 +519,9 @@ fn compare_mc_versions(a: &str, b: &str) -> i32 {
         }
 
         let parts: Vec<&str> = s.split('.').collect();
-        let major = parts.first().and_then(|p| p.parse().ok()).unwrap_or(0);
-        let minor = parts.get(1).and_then(|p| p.parse().ok()).unwrap_or(0);
-        let patch = parts.get(2).and_then(|p| p.parse().ok()).unwrap_or(0);
+        let major = parse_numeric_part(parts.first());
+        let minor = parse_numeric_part(parts.get(1));
+        let patch = parse_numeric_part(parts.get(2));
         (major, minor, patch)
     };
 
@@ -920,6 +946,7 @@ mod tests {
 
     #[test]
     fn test_get_required_java_version() {
+        assert_eq!(get_required_java_version("26.1-snapshot-1"), 25);
         assert_eq!(get_required_java_version("26.1.2"), 25);
         assert_eq!(get_required_java_version("26.1"), 25);
         assert_eq!(get_required_java_version("1.20.6"), 21);
@@ -953,6 +980,9 @@ mod tests {
         assert_eq!(compare_mc_versions("1.21", "1.20.5"), 1);
         assert_eq!(compare_mc_versions("26.1.2", "1.21.11"), 1);
         assert_eq!(compare_mc_versions("26.1.2", "26.1"), 1);
+        assert_eq!(compare_mc_versions("26.1-snapshot-1", "26.1"), 0);
+        assert_eq!(compare_mc_versions("26.1.2-rc1", "26.1"), 1);
+        assert_eq!(compare_mc_versions("1.21.11-rc1", "1.21.10"), 1);
         assert_eq!(compare_mc_versions("1.18", "1.17"), 1);
     }
 

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -20,7 +20,10 @@ use shard::logs::{
 };
 use shard::minecraft::{launch, prepare};
 use shard::modpack::import_mrpack;
-use shard::ops::{finish_device_code_flow, parse_loader, resolve_input, resolve_launch_account};
+use shard::ops::{
+    ensure_fresh_account, finish_device_code_flow, parse_loader, resolve_input,
+    resolve_launch_account,
+};
 use shard::paths::Paths;
 use shard::profile::{
     ContentRef, Loader, Runtime, clone_profile, create_profile, delete_profile, diff_profiles,
@@ -39,7 +42,7 @@ use shard::template::{
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[derive(Parser, Debug)]
 #[command(name = "shard", version, about = "Minimal Minecraft launcher")]
@@ -240,6 +243,11 @@ enum AccountCommand {
     Remove { id: String },
     /// Show account profile info (skin, cape)
     Info { id: Option<String> },
+    /// Validate and refresh account tokens without launching Minecraft
+    Check {
+        /// Account to check (default: active)
+        id: Option<String>,
+    },
     /// Export accounts to a JSON file (includes tokens for portability)
     Export {
         /// Output file path (default: accounts_export.json)
@@ -1140,6 +1148,20 @@ fn handle_account_command(paths: &Paths, command: AccountCommand) -> Result<()> 
                     println!("(could not fetch skin/cape info: {e})");
                 }
             }
+        }
+        AccountCommand::Check { id } => {
+            let account = ensure_fresh_account(paths, id)?;
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .context("system time is before Unix epoch")?
+                .as_secs();
+            let msa_secs = account.msa.expires_at.saturating_sub(now);
+            let mc_secs = account.minecraft.expires_at.saturating_sub(now);
+
+            println!("Account: {} ({})", account.username, account.uuid);
+            println!("MSA token: valid for {} minute(s)", msa_secs / 60);
+            println!("Minecraft token: valid for {} minute(s)", mc_secs / 60);
+            println!("Token refresh: ok");
         }
         AccountCommand::Export { output } => {
             let accounts = load_accounts(paths)?;

--- a/web/content/cli.mdx
+++ b/web/content/cli.mdx
@@ -97,6 +97,9 @@ shard account list
 # Set active account
 shard account use <username>
 
+# Validate/refresh active account tokens
+shard account check
+
 # Remove an account
 shard account remove <username>
 


### PR DESCRIPTION
## Summary
- Add `shard account check` to validate and refresh the selected account without launching Minecraft.
- Update Java compatibility rules for Minecraft `26.1+`, which Mojang's manifest marks as requiring Java 25.
- Document the new account check command in the README and CLI docs.

## Validation
- `cargo check -p shard`
- `cargo test -p shard`
- `cargo run -p shard -- account check`
- `shard launch latest-release-26.1.2 --prepare-only` now reports the Java 25 requirement instead of treating the latest release as Java 21-compatible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive CLI/docs plus localized Java version logic; account check touches auth refresh but mirrors existing launch behavior.
> 
> **Overview**
> Adds **`shard account check`** so you can validate and refresh Microsoft/Minecraft tokens for the active (or chosen) account without launching the game. It reuses the same refresh path as launch (`ensure_fresh_account`) and prints remaining MSA and Minecraft token lifetime plus a success line.
> 
> Updates **Java selection** for newer Minecraft versions: **`26.1+` now requires Java 25**, with version comparison tightened so strings like `26.1.2-rc1` and `26.1-snapshot-1` compare correctly against requirement thresholds. README and CLI docs document the new account command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 090b420221cc51da62c8b8d67574c00655ca5525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->